### PR TITLE
Refactor(InventoryRepository): corrected Difficulty enum usage in InventoryRepository

### DIFF
--- a/src/main/java/com/repository/InventoryRepository.java
+++ b/src/main/java/com/repository/InventoryRepository.java
@@ -41,7 +41,7 @@ public class InventoryRepository {
         log.debug("Getting room count by difficulty");
         return roomDAO.findAll().stream()
     .collect(Collectors.groupingBy(
-        room -> Difficulty.valueOf(room.getDifficulty()),
+        Room::getDifficulty,
         Collectors.counting()));
     }
     


### PR DESCRIPTION
### ♻️ Refactor: Fix enum usage in InventoryRepository

✅ **Changes made**:
- Corrected a bug where `Difficulty.valueOf(Difficulty)` was called incorrectly.
- Replaced with direct use of the existing `Difficulty` enum value from the `Room` object.

📌 **Purpose**:
- Fix compilation error caused by misuse of the `valueOf` method.
- Improve clarity and correctness of room grouping logic by difficulty.

---

### ♻️ Refactorización: Corrección del uso de enums en InventoryRepository

✅ **Cambios realizados**:
- Se corrigió el uso incorrecto de `Difficulty.valueOf(Difficulty)` que causaba error de compilación.
- Sustituido por el uso directo del valor `Difficulty` ya presente en el objeto `Room`.

📌 **Objetivo**:
- Eliminar el error de compilación y mejorar la lógica de agrupación de salas por dificultad.
- Alinear el código con buenas prácticas de enums en Java.
