### PR TITLE
REFACTOR: Fix EventManager constructor to use new list in case of no parameter

### DIFF
--- a/src/main/java/com/utils/EventManager.java
+++ b/src/main/java/com/utils/EventManager.java
@@ -11,7 +11,7 @@ public class EventManager implements Observable {
 
     public EventManager(List<Observer> observers) {
 
-        this.observers = new ArrayList<>();
+        this.observers = observers != null ? observers : new ArrayList<>();
     }
     @Override
     public void addObserver(Observer observer) {


### PR DESCRIPTION
REFACTOR: Fix EventManager constructor to use new list in case of no parameter