### PR TITLE
feat(test): Add unit tests for Clue, Player, and Puzzle models

### DIFF
--- a/src/test/java/com/model/ClueTest.java
+++ b/src/test/java/com/model/ClueTest.java
@@ -1,0 +1,38 @@
+package com.model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ClueTest {
+
+    @Test
+    void testRevealSetsRevealedTrue() {
+        Clue clue = Clue.builder()
+                .id(1)
+                .description("Behind the painting")
+                .theme("Mystery")
+                .price(0.0)
+                .build();
+
+        assertFalse(clue.isRevealed(), "Clue should not be revealed by default");
+
+        clue.reveal();
+
+        assertTrue(clue.isRevealed(), "Clue should be marked as revealed after calling reveal()");
+    }
+
+    @Test
+    void testClueProperties() {
+        Clue clue = Clue.builder()
+                .id(2)
+                .description("Hidden in drawer")
+                .theme("Horror")
+                .price(5.0)
+                .build();
+
+        assertEquals(2, clue.getId());
+        assertEquals("Hidden in drawer", clue.getDescription());
+        assertEquals("Horror", clue.getTheme());
+        assertEquals(5.0, clue.getPrice());
+    }
+}

--- a/src/test/java/com/model/PlayerTest.java
+++ b/src/test/java/com/model/PlayerTest.java
@@ -1,0 +1,66 @@
+package com.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlayerTest {
+
+    @Test
+    void testAddTicketAddsToList() {
+        Player player = Player.builder()
+                .id(1)
+                .name("Carlos")
+                .email("carlos@example.com")
+                .build();
+
+        Room room = Room.builder()
+                .id(101)
+                .name("Haunted Mansion")
+                .theme("Terror")
+                .difficulty(null)
+                .price(30.0)
+                .build();
+
+        TicketSale ticket = TicketSale.builder()
+                .id(5001)
+                .player(player)
+                .room(room)
+                .price(30.0)
+                .saleDate(LocalDateTime.now())
+                .build();
+
+        player.addTicket(ticket);
+
+        List<TicketSale> tickets = player.getTickets();
+        assertEquals(1, tickets.size());
+        assertTrue(tickets.contains(ticket), "The ticket should be added to the player's list.");
+    }
+
+    @Test
+    void testAdvanceRoomProgressIncrementsValue() {
+        Player player = Player.builder()
+                .id(2)
+                .name("Laura")
+                .email("laura@example.com")
+                .roomProgress(0)
+                .build();
+
+        player.advanceRoomProgress();
+        assertEquals(1, player.getRoomProgress(), "Room progress should increment by 1.");
+    }
+
+    @Test
+    void testGetNotificationLogsMessage() {
+        Player player = Player.builder()
+                .id(3)
+                .name("Mario")
+                .email("mario@example.com")
+                .build();
+
+        assertDoesNotThrow(() -> player.getNotification("🧩 Has desbloqueado una pista"));
+    }
+}

--- a/src/test/java/com/model/PuzzleTest.java
+++ b/src/test/java/com/model/PuzzleTest.java
@@ -1,0 +1,58 @@
+package com.model;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PuzzleTest {
+
+    @Test
+    void testInitialSolvedIsFalse() {
+        Puzzle puzzle = Puzzle.builder()
+                .id(1)
+                .description("Code box")
+                .solution("1234")
+                .build();
+
+        assertFalse(puzzle.isSolved(), "Puzzle should not be solved by default");
+    }
+
+    @Test
+    void testAttemptCorrectSolutionMarksAsSolved() {
+        Puzzle puzzle = Puzzle.builder()
+                .solution("OpenSesame")
+                .build();
+
+        boolean result = puzzle.attemptSolution("opensesame");
+
+        assertTrue(result, "Correct solution should return true");
+        assertTrue(puzzle.isSolved(), "Puzzle should be marked as solved");
+    }
+
+    @Test
+    void testAttemptWrongSolutionReturnsFalse() {
+        Puzzle puzzle = Puzzle.builder()
+                .solution("42")
+                .build();
+
+        boolean result = puzzle.attemptSolution("43");
+
+        assertFalse(result, "Incorrect solution should return false");
+        assertFalse(puzzle.isSolved(), "Puzzle should remain unsolved");
+    }
+
+    @Test
+    void testAddClueAddsToList() {
+        Puzzle puzzle = Puzzle.builder().build();
+        Clue clue = Clue.builder()
+                .id(1)
+                .description("Check under the table")
+                .theme("Mystery")
+                .price(0)
+                .build();
+
+        puzzle.addClue(clue);
+
+        assertEquals(1, puzzle.getClues().size(), "Clue list should contain one clue");
+        assertTrue(puzzle.getClues().contains(clue), "Clue should be in the clue list");
+    }
+}


### PR DESCRIPTION
# ✅ Add unit tests for Clue, Player, and Puzzle models



This PR adds unit tests for three core model classes: `Clue`, `Player`, and `Puzzle`.

### ✅ What's included:
- `ClueTest`: verifies the default state (`revealed = false`) and the behavior of the `reveal()` method.
- `PlayerTest`: tests the `addTicket()` method, room progress tracking, and the observer notification via `getNotification()`.
- `PuzzleTest`: validates puzzle creation, clue association, and the solution-checking logic with `attemptSolution()`.

These unit tests ensure the correct behavior of the domain models in isolation and lay a solid foundation for future integration testing.

---


Esta PR añade pruebas unitarias para tres clases clave del modelo: `Clue`, `Player` y `Puzzle`.

### ✅ Contenido incluido:
- `ClueTest`: verifica el estado por defecto (`revealed = false`) y el funcionamiento del método `reveal()`.
- `PlayerTest`: comprueba el método `addTicket()`, el avance en el progreso de sala y la recepción de notificaciones con `getNotification()`.
- `PuzzleTest`: valida la creación del enigma, la asociación de pistas y la lógica de comprobación de solución mediante `attemptSolution()`.

Estas pruebas unitarias aseguran el comportamiento correcto de los modelos de dominio de forma aislada y preparan el terreno para las futuras pruebas de integración.
