### PR TITLE
fix: Add Room reference to Clue and DecorationItem for consistency

### DIFF
--- a/src/main/java/com/model/Clue.java
+++ b/src/main/java/com/model/Clue.java
@@ -11,6 +11,7 @@ public class Clue {
     private String description;
     private String theme;
     private double price;
+    private Room room;
 
     @Builder.Default
     private boolean revealed = false;

--- a/src/main/java/com/model/DecorationItem.java
+++ b/src/main/java/com/model/DecorationItem.java
@@ -12,6 +12,7 @@ public class DecorationItem {
     private String name;
     private Material material;
     private double price;
+    private Room room;
 
     @Builder.Default
     private boolean interactive = false;

--- a/src/test/java/com/integration/InventoryIntegrationTest.java
+++ b/src/test/java/com/integration/InventoryIntegrationTest.java
@@ -1,0 +1,56 @@
+package com.integration;
+
+import com.enums.Difficulty;
+import com.enums.Material;
+import com.model.Clue;
+import com.model.DecorationItem;
+import com.model.Room;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InventoryIntegrationTest {
+
+    @Test
+    void testRoomInventoryIntegration() {
+        // Crear una sala
+        Room room = Room.builder()
+                .id(1)
+                .name("Haunted Mansion")
+                .difficulty(Difficulty.MEDIUM)
+                .build();
+
+        // Crear pista y decoración
+        Clue clue = Clue.builder()
+                .id(1)
+                .description("Look behind the mirror")
+                .theme("Horror")
+                .price(0.0)
+                .room(room)
+                .build();
+
+        DecorationItem item = DecorationItem.builder()
+                .id(1)
+                .name("Old Mirror")
+                .material(Material.GLASS)
+                .room(room)
+                .build();
+
+        // Asignar objetos a la sala
+        room.addClue(clue);
+        room.addDecorationItem(item);
+
+        // Validaciones
+        assertEquals(1, room.getClues().size(), "Room should contain 1 clue");
+        assertEquals(1, room.getDecorationItems().size(), "Room should contain 1 decoration item");
+
+        // Verificamos contenido específico
+        assertEquals("Look behind the mirror", room.getClues().get(0).getDescription());
+        assertEquals("Old Mirror", room.getDecorationItems().get(0).getName());
+
+        // Validamos que los objetos estén correctamente vinculados
+        assertEquals(room, room.getDecorationItems().get(0).getRoom(), "Decoration item should be linked to the room");
+        assertEquals(room, item.getRoom(), "Decoration item should be linked to the room");
+
+    }
+}

--- a/src/test/java/com/integration/RoomIntegrationTest.java
+++ b/src/test/java/com/integration/RoomIntegrationTest.java
@@ -1,0 +1,60 @@
+package com.integration;
+
+import com.enums.Difficulty;
+import com.factory.RoomFactoryEasy;
+import com.interfaces.AbstractFactory;
+import com.model.*;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoomIntegrationTest {
+
+    @Test
+    void testPlayerSolvesPuzzleAndReceivesNotification() {
+        // Crear sala con factory
+        AbstractFactory factory = new RoomFactoryEasy();
+        Room room = factory.createRoom("Adventure");
+
+        // Crear puzzle y añadir una pista
+        Puzzle puzzle = Puzzle.builder()
+                .id(1)
+                .description("Enter the correct code")
+                .solution("1234")
+                .build();
+
+        Clue clue = Clue.builder()
+                .id(1)
+                .description("It's a four-digit number")
+                .theme("Adventure")
+                .price(0.0)
+                .build();
+
+        puzzle.addClue(clue);
+        room.addPuzzle(puzzle);
+
+        // Crear jugador y añadirlo como observer
+        Player player = Player.builder()
+                .id(1)
+                .name("Alex")
+                .email("alex@example.com")
+                .build();
+
+        room.addObserver(player);
+
+        // Resolver el enigma correctamente
+        boolean solved = puzzle.attemptSolution("1234");
+
+        // Notificar que se resolvió un puzzle
+        if (solved) {
+            room.notifyObservers("✅ Puzzle solved: " + puzzle.getDescription());
+        }
+
+        // Verificar que el puzzle se marcó como resuelto
+        assertTrue(puzzle.isSolved(), "Puzzle should be marked as solved");
+
+        // No podemos verificar la notificación si Player solo loguea
+        // Pero validamos que la lógica se ejecutó sin errores
+    }
+}

--- a/src/test/java/com/integration/TicketCertificateDAOIntegrationTest.java
+++ b/src/test/java/com/integration/TicketCertificateDAOIntegrationTest.java
@@ -1,0 +1,57 @@
+package com.integration;
+
+import com.dao.TicketSaleDAOImpl;
+import com.enums.Difficulty;
+import com.model.Player;
+import com.model.Room;
+import com.model.TicketSale;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TicketSaleDAOIntegrationTest {
+
+    private TicketSaleDAOImpl ticketSaleDAO;
+
+    @BeforeEach
+    void setup() {
+        ticketSaleDAO = new TicketSaleDAOImpl();
+    }
+
+    @Test
+    void testCreateAndRetrieveTicketByPlayer() {
+        // Crear player y room
+        Player player = Player.builder()
+                .id(1)
+                .name("Lucas")
+                .email("lucas@example.com")
+                .build();
+
+        Room room = Room.builder()
+                .id(1)
+                .name("Pharaoh's Tomb")
+                .difficulty(Difficulty.HARD)
+                .build();
+
+        // Crear ticket
+        TicketSale ticket = TicketSale.builder()
+                .player(player)
+                .room(room)
+                .price(30.0)
+                .saleDate(LocalDateTime.now())
+                .build();
+
+        TicketSale created = ticketSaleDAO.create(ticket);
+        assertNotNull(created, "Ticket should be created");
+        assertEquals("Lucas", created.getPlayer().getName());
+
+        // Buscar por playerId
+        List<TicketSale> sales = ticketSaleDAO.findByPlayerId(1);
+        assertEquals(1, sales.size(), "Player should have 1 ticket sale");
+        assertEquals(room.getName(), sales.get(0).getRoom().getName());
+    }
+}

--- a/src/test/java/com/integration/TicketCertificateIntegrationTest.java
+++ b/src/test/java/com/integration/TicketCertificateIntegrationTest.java
@@ -1,0 +1,55 @@
+package com.integration;
+
+import com.enums.Difficulty;
+import com.model.Certificate;
+import com.model.Player;
+import com.model.Room;
+import com.model.TicketSale;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TicketCertificateIntegrationTest {
+
+    @Test
+    void testTicketAndCertificateAssociation() {
+        // Crear jugador
+        Player player = Player.builder()
+                .id(1)
+                .name("Emma")
+                .email("emma@example.com")
+                .build();
+
+        // Crear sala
+        Room room = Room.builder()
+                .id(1)
+                .name("Mystery Library")
+                .difficulty(Difficulty.MEDIUM)
+                .build();
+
+        // Crear ticket
+        TicketSale ticket = TicketSale.builder()
+                .id(1)
+                .player(player)
+                .room(room)
+                .price(20.0)
+                .saleDate(LocalDateTime.now())
+                .build();
+
+        // Crear certificado
+        Certificate certificate = Certificate.builder()
+                .id(1)
+                .player(player)
+                .roomName(room.getName())
+                .certificateDate(LocalDateTime.now())
+                .build();
+
+        // Validaciones
+        assertEquals("Emma", ticket.getPlayer().getName(), "Ticket should be linked to player Emma");
+        assertEquals("Mystery Library", ticket.getRoom().getName(), "Room should be linked to the ticket");
+        assertEquals("Mystery Library", certificate.getRoomName(), "Certificate room name should match");
+        assertEquals(player, certificate.getPlayer(), "Certificate should be linked to the player");
+    }
+}


### PR DESCRIPTION
### ✅ What’s fixed

This PR adds the missing `private Room room;` field to the following model classes:

- `Clue`
- `DecorationItem`

This field was required to validate and complete the integration tests previously introduced in `feature/test-acocinas`.

---

### 🧪 Notes

- No changes to business logic were made.
- All integration tests pass after rebasing with the latest feature branch.
- This update ensures proper object association and allows tests like `InventoryIntegrationTest` to assert correctly.

---

### 📂 Related branch
- `fix/classes-methods`

---

### ✅ Qué se ha corregido

Este Pull Request añade el campo faltante `private Room room;` a las siguientes clases del modelo:

- `Clue`
- `DecorationItem`

Este campo era necesario para validar y completar los tests de integración introducidos anteriormente en la rama `feature/test-acocinas`.

---

### 🧪 Notas

- No se ha modificado ninguna lógica de negocio.
- Todos los tests de integración pasan tras hacer `rebase` con la rama de funcionalidades más reciente.
- Esta mejora permite mantener la coherencia en las asociaciones entre objetos y habilita validaciones correctas en tests como `InventoryIntegrationTest`.

---

### 📂 Rama relacionada
- `fix/classes-methods`
