### PR TITLE
Add integration tests for RoomMenu

### DIFF
--- a/src/test/java/com/menu/RoomMenuAddClueAndPuzzleTest.java
+++ b/src/test/java/com/menu/RoomMenuAddClueAndPuzzleTest.java
@@ -1,0 +1,56 @@
+package com.menu;
+
+import com.model.Clue;
+import com.model.Puzzle;
+import com.model.Room;
+import com.service.InventoryService;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Scanner;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RoomMenuAddClueAndPuzzleTest {
+
+    @Test
+    void testAddClueAndPuzzleToRoom() {
+        String simulatedInput = String.join("\n",
+                "1",                     // Create room
+                "Aventura",              // Room theme
+                "EASY",                  // Difficulty
+
+                "3",                     // Add clue
+                "1",                     // Room ID
+                "La llave está en la caja", // Clue description
+                "Misterio",              // Clue theme
+
+                "5",                     // Add puzzle
+                "1",                     // Room ID
+                "Resuelve el acertijo",  // Puzzle description
+                "1234",                  // Puzzle solution
+
+                "0",                     // Exit
+                ""                       // Avoid scanner error
+        );
+        Scanner scanner = new Scanner(new ByteArrayInputStream(simulatedInput.getBytes(StandardCharsets.UTF_8)));
+        InventoryService inventoryService = new InventoryService();
+        RoomMenu roomMenu = new RoomMenu(inventoryService, scanner);
+
+        roomMenu.manageRoom();
+
+        Room room = inventoryService.getRoomById(1);
+        assertNotNull(room);
+
+        List<Clue> clues = room.getClues();
+        List<Puzzle> puzzles = room.getPuzzles();
+
+        assertFalse(clues.isEmpty());
+        assertEquals("La llave está en la caja", clues.getFirst().getDescription());
+
+        assertFalse(puzzles.isEmpty());
+        assertEquals("Resuelve el acertijo", puzzles.getFirst().getDescription());
+    }
+}

--- a/src/test/java/com/menu/RoomMenuIntegrationTest.java
+++ b/src/test/java/com/menu/RoomMenuIntegrationTest.java
@@ -1,0 +1,40 @@
+package com.menu;
+
+import com.model.Room;
+import com.service.InventoryService;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RoomMenuIntegrationTest {
+
+    @Test
+    void testFullRoomMenuFlow_createAndDeleteRoom() throws Exception {
+        /*
+         * Flujo:
+         * 1 → Crear Room: tema = "Terror", dificultad = "EASY"
+         * 2 → Eliminar Room con ID = 1
+         * 0 → Salir
+         */
+        String simulatedInput = String.join("\n",
+                "1", "Terror", "EASY",  // Crear Room
+                "2", "1",               // Eliminar Room
+                "0",// Salir
+                ""// Evitamos el error que da el test ya que no se aprieta enter y la limpieza de buffer da error
+        );
+
+        Scanner scanner = new Scanner(new ByteArrayInputStream(simulatedInput.getBytes(StandardCharsets.UTF_8)));
+        InventoryService inventoryService = new InventoryService();
+        RoomMenu roomMenu = new RoomMenu(inventoryService, scanner);
+
+        roomMenu.manageRoom();
+
+        // 🔍 Assert real: la Room debe haber sido eliminada
+        Room deletedRoom = inventoryService.getRoomById(1);
+        assertNull(deletedRoom, "La sala con ID 1 debería haber sido eliminada del inventario.");
+    }
+}


### PR DESCRIPTION
# Add integration tests for RoomMenu

This PR adds two new end-to-end integration tests for the `RoomMenu` console workflow:

1. **RoomMenuIntegrationTest**  
   - Covers the basic menu flow: room creation and deletion.  
   - Verifies that after exiting the menu, the room has been removed from `InventoryService`.

2. **RoomMenuAddClueAndPuzzleTest**  
   - Covers room creation, adding a clue, and adding a puzzle.  
   - Asserts the presence of the added `Clue` and `Puzzle` with their descriptions.  
   - Handles the final `"0"` exit input plus an extra blank line to satisfy the internal `Scanner.nextLine()` cleanup.

These tests validate the integration of `RoomService`, `RoomContentService`, and `InventoryService` through the user menu and ensure robust handling of `Scanner` input.

---

# Añadir tests de integración para RoomMenu

Este PR incorpora dos pruebas de integración de extremo a extremo para el flujo de consola de `RoomMenu`:

1. **RoomMenuIntegrationTest**  
   - Cubre el flujo básico del menú: creación y eliminación de sala.  
   - Verifica que, tras salir del menú, la sala ya no exista en `InventoryService`.

2. **RoomMenuAddClueAndPuzzleTest**  
   - Cubre la creación de la sala, la adición de una pista y la adición de un puzzle.  
   - Comprueba la presencia de la `Clue` y el `Puzzle` añadidos con sus descripciones.  
   - Incluye la entrada final `"0"` y una línea en blanco extra para el `Scanner.nextLine()` interno.

Estas pruebas validan la integración de `RoomService`, `RoomContentService` e `InventoryService` a través del menú y garantizan un manejo robusto de la entrada del `Scanner`.
